### PR TITLE
Implement quadratic interpolation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,13 @@ Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Changed
+
+- The pitch detection algorithm is now more accurate, using quadratic
+  interpolation as described in [the MPM
+  paper](http://www.cs.otago.ac.nz/tartini/papers/A_Smarter_Way_to_Find_Pitch.pdf)
+  to get a better estimate of the clearest frequency.
+
 ## [2.0.3] - 2021-01-02
 
 ### Added


### PR DESCRIPTION
Section 5 of [the MPM
paper](http://miracle.otago.ac.nz/tartini/papers/A_Smarter_Way_to_Find_Pitch.pdf)
suggests using quadratic interpolation to find a more accurate value for
the key maximum of the NSDF output. Previously, this was unimplemented,
and the integer index was used directly, but this led to sub-optimal
results with certain pitches. With quadratic interpolation, this seems
to be somewhat mitigated, although there may be additional ways to
improve the results.

See #11 for more context on why this was implemented; the test note of
F#5 mentioned in the issue was added as a test case to show that this
change improves the results for that example.