### PR TITLE
fix: export package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
   "main": "index.js",
   "types": "index.d.ts",
   "exports": {
+    "./package.json": "./package.json",
     ".": {
       "types": "./index.d.ts",
       "import": "./index.js"


### PR DESCRIPTION
Apparently, React Native and various bundler tools expect to be able to
import/require package.json, which will fail if `exports` is being used
but not exporting package.json:
https://github.com/uuidjs/uuid/issues/444

Fixes #107