### PR TITLE
ci: decrease Dependabot frequency to monthly

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,7 +3,7 @@ updates:
   - package-ecosystem: npm
     directory: /
     schedule:
-      interval: weekly
+      interval: monthly
     commit-message:
       prefix: "build(deps):"
       prefix-development: "build(dev):"


### PR DESCRIPTION
This repository has only one non-development dependency, which has not been updated in two years. It is unnecessary to check for new dependencies every week.